### PR TITLE
Namespace export

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -3,7 +3,7 @@
   "parser": "@typescript-eslint/parser",
   "parserOptions": {
     "sourceType": "module",
-    "project": ["./tsconfig.json"]
+    "project": ["./tsconfig.dev.json"]
   },
   "env": {
     "node": true
@@ -21,8 +21,9 @@
     "@typescript-eslint/no-floating-promises": "error",
     "eqeqeq": "error",
     "no-console": "error",
+    "@typescript-eslint/consistent-type-imports": "warn",
     "@typescript-eslint/no-explicit-any": "off",
-    "@typescript-eslint/consistent-type-imports": "warn"
+    "@typescript-eslint/no-namespace": "off"
   },
   "overrides": [
     {

--- a/examples/simple_schema.ts
+++ b/examples/simple_schema.ts
@@ -1,4 +1,4 @@
-import { ch } from '../src'
+import { ch } from '@clickhouse/schema'
 
 void (async () => {
   enum UserRole {

--- a/examples/simple_schema.ts
+++ b/examples/simple_schema.ts
@@ -1,13 +1,12 @@
-import * as ch from '../src'
-import type { Infer } from '../src'
-import { createSchema } from '../src'
+import { ch } from '../src'
 
 void (async () => {
   enum UserRole {
     User = 'User',
     Admin = 'Admin',
   }
-  const userSchema = createSchema({
+
+  const userSchema = ch.createSchema({
     id: ch.UInt64,
     f64: ch.Float64,
     name: ch.String,
@@ -18,7 +17,7 @@ void (async () => {
     registeredAt: ch.DateTime64(3, 'Europe/Amsterdam'),
   })
 
-  type Data = Infer<typeof userSchema.shape>
+  type Data = ch.Infer<typeof userSchema.shape>
 
   const usersTable = new ch.Table({
     name: 'users',

--- a/examples/tsconfig.json
+++ b/examples/tsconfig.json
@@ -1,0 +1,11 @@
+{
+  "extends": "../tsconfig.json",
+  "include": ["./**/*.ts"],
+  "compilerOptions": {
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "paths": {
+      "@clickhouse/schema": ["src/index.ts"]
+    }
+  }
+}

--- a/package.json
+++ b/package.json
@@ -29,7 +29,7 @@
   "main": "dist/index.js",
   "types": "dist/index.d.ts",
   "scripts": {
-    "typecheck": "tsc --project tsconfig.json --noEmit",
+    "typecheck": "tsc --project tsconfig.dev.json --noEmit",
     "lint": "eslint . --ext .ts",
     "lint:fix": "eslint --fix . --ext .ts",
     "prepare": "husky"

--- a/src/index.ts
+++ b/src/index.ts
@@ -1,6 +1,59 @@
-export * from './schema'
-export * from './types'
-export * from './table'
-export * from './engines'
-export * from './common'
-export * from './where'
+import type * as common from './common'
+import * as schema from './schema'
+import * as types from './types'
+import * as table from './table'
+import * as engines from './engines'
+import * as where from './where'
+
+export namespace ch {
+  export type Infer<S extends common.Shape> = common.Infer<S>
+
+  export const Schema = schema.Schema
+  export const createSchema = schema.createSchema
+
+  export const Table = table.Table
+  export type TableOptions<S extends common.Shape> = table.TableOptions<S>
+  export type CreateTableOptions<S extends common.Shape> =
+    table.CreateTableOptions<S>
+
+  export type TableEngine = engines.TableEngine
+  export const MergeTree = engines.MergeTree
+  export const ReplicatedMergeTree = engines.ReplicatedMergeTree
+  export const ReplacingMergeTree = engines.ReplacingMergeTree
+  export const SummingMergeTree = engines.SummingMergeTree
+  export const AggregatingMergeTree = engines.AggregatingMergeTree
+  export const CollapsingMergeTree = engines.CollapsingMergeTree
+  export const VersionedCollapsingMergeTree =
+    engines.VersionedCollapsingMergeTree
+  export const GraphiteMergeTree = engines.GraphiteMergeTree
+
+  export const Bool = types.Bool
+  export const Int8 = types.Int8
+  export const Int16 = types.Int16
+  export const Int32 = types.Int32
+  export const Int64 = types.Int64
+  export const UInt8 = types.UInt8
+  export const UInt16 = types.UInt16
+  export const UInt32 = types.UInt32
+  export const UInt64 = types.UInt64
+  export const Float32 = types.Float32
+  export const Float64 = types.Float64
+  export const String = types.String
+  export const FixedString = types.FixedString
+  export const UUID = types.UUID
+  export const IPv4 = types.IPv4
+  export const IPv6 = types.IPv6
+  export const Date = types.Date
+  export const Date32 = types.Date32
+  export const DateTime = types.DateTime
+  export const DateTime64 = types.DateTime64
+  export const LowCardinality = types.LowCardinality
+  export const Nullable = types.Nullable
+  export const Array = types.Array
+  export const Enum = types.Enum
+  export const Map = types.Map
+
+  export const Eq = where.Eq
+  export const And = where.And
+  export const Or = where.Or
+}

--- a/src/query_formatter.ts
+++ b/src/query_formatter.ts
@@ -1,6 +1,6 @@
 import type { NonEmptyArray, Shape } from './common'
-import type { CreateTableOptions, TableOptions } from './index'
 import type { WhereExpr } from './where'
+import type { CreateTableOptions, TableOptions } from './table'
 
 export type CreateTableFormatterOptions<S extends Shape> = TableOptions<S> &
   CreateTableOptions<S> & {

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -1,0 +1,18 @@
+{
+  "extends": "./tsconfig.json",
+  "include": ["src/**/*.ts", "examples/**/*.ts", "__tests__/**/*.ts"],
+  "compilerOptions": {
+    "module": "NodeNext",
+    "moduleResolution": "NodeNext",
+    "noUnusedLocals": false,
+    "noUnusedParameters": false,
+    "outDir": "out",
+    "baseUrl": "./",
+    "paths": {
+      "@test/*": ["__tests__/*"]
+    }
+  },
+  "ts-node": {
+    "require": ["tsconfig-paths/register"]
+  }
+}

--- a/tsconfig.dev.json
+++ b/tsconfig.dev.json
@@ -9,7 +9,8 @@
     "outDir": "out",
     "baseUrl": "./",
     "paths": {
-      "@test/*": ["__tests__/*"]
+      "@test/*": ["__tests__/*"],
+      "@clickhouse/schema": ["src/index.ts"]
     }
   },
   "ts-node": {

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -23,5 +23,5 @@
     "baseUrl": "./"
   },
   "exclude": ["node_modules"],
-  "include": ["./src/**/*.ts", "./examples/**/*.ts"]
+  "include": ["./src/**/*.ts"]
 }


### PR DESCRIPTION
Let's try it for now, as it seems to be more convenient to use (`import { ch } from '@clickhouse/schema'` as you type instead of requiring a manual `import * as ch from '@clickhouse/schema'` or similar).